### PR TITLE
Asg rolling_update_policy changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 Changelog for paco.models
 =========================
 
-7.0.3 (unreleased)
+8.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+### Migration
+
+- ASG field's ``update_policy_max_batch_size`` and ``update_policy_min_instances_in_service`` are removed.
+  Instead use the ASG field ``rolling_update_policy`` and set ``max_batch_size`` and ``min_instances_in_service``.
 
 
 7.0.2 (2020-03-14)

--- a/fixtures/pacodemo/netenv/pacodemo.yml
+++ b/fixtures/pacodemo/netenv/pacodemo.yml
@@ -333,6 +333,12 @@ applications:
             max_instances: 3
             min_instances: 1
             desired_capacity: 1
+            rolling_update_policy:
+              enabled: true
+              max_batch_size: 1
+              min_instances_in_service: 0
+              pause_time: PT1M
+              wait_on_resource_signals: false
             target_groups:
               - paco.ref netenv.pacodemo.applications.app.groups.site.resources.alb.target_groups.app
             security_groups:
@@ -340,8 +346,6 @@ applications:
             segment: webapp
             termination_policies:
               - Default
-            update_policy_max_batch_size: 1
-            update_policy_min_instances_in_service: 0
             cfn_init:
               parameters:
                 TestString: 'catdog'
@@ -540,8 +544,6 @@ applications:
             segment: public
             termination_policies:
               - Default
-            update_policy_max_batch_size: 1
-            update_policy_min_instances_in_service: 0
             security_groups:
               - paco.ref netenv.pacodemo.network.vpc.security_groups.app.bastion
             user_data_script: |

--- a/src/paco/models/applications.py
+++ b/src/paco/models/applications.py
@@ -462,8 +462,9 @@ class BlockDeviceMapping(Parent):
     }
 
 @implementer(schemas.IASGRollingUpdatePolicy)
-class ASGRollingUpdatePolicy(Named, Deployable):
+class ASGRollingUpdatePolicy(Named):
     title = "RollingUpdatePolicy"
+    enabled = FieldProperty(schemas.IASGRollingUpdatePolicy['enabled'])
     max_batch_size = FieldProperty(schemas.IASGRollingUpdatePolicy['max_batch_size'])
     min_instances_in_service = FieldProperty(schemas.IASGRollingUpdatePolicy['min_instances_in_service'])
     pause_time = FieldProperty(schemas.IASGRollingUpdatePolicy['pause_time'])
@@ -477,8 +478,6 @@ class ASG(Resource, Monitorable):
     desired_capacity_ignore_changes =  FieldProperty(schemas.IASG['desired_capacity_ignore_changes'])
     min_instances =  FieldProperty(schemas.IASG['min_instances'])
     max_instances =  FieldProperty(schemas.IASG['max_instances'])
-    update_policy_max_batch_size =  FieldProperty(schemas.IASG['update_policy_max_batch_size'])
-    update_policy_min_instances_in_service =  FieldProperty(schemas.IASG['update_policy_min_instances_in_service'])
     associate_public_ip_address =  FieldProperty(schemas.IASG['associate_public_ip_address'])
     cooldown_secs =  FieldProperty(schemas.IASG['cooldown_secs'])
     ebs_optimized =  FieldProperty(schemas.IASG['ebs_optimized'])
@@ -518,6 +517,7 @@ class ASG(Resource, Monitorable):
         self.load_balancers = []
         self.efs_mounts = []
         self.ebs_volume_mounts = []
+        self.rolling_update_policy = ASGRollingUpdatePolicy('rolling_update_policy', self)
 
     def get_aws_name(self):
         "AutoScalingGroup Name for AWS"

--- a/src/paco/models/schemas.py
+++ b/src/paco/models/schemas.py
@@ -4066,10 +4066,16 @@ class IBlockDeviceMapping(IParent):
         required=False
     )
 
-class IASGRollingUpdatePolicy(INamed, IDeployable):
+class IASGRollingUpdatePolicy(INamed):
     """
-Auto Scaling Group Roling Update Policy
+AutoScalingRollingUpdate Policy
     """
+    enabled = schema.Bool(
+        title="Enable an UpdatePolicy for the ASG",
+        description="",
+        default=True,
+        required=False,
+    )
     max_batch_size = schema.Int(
         title="Maximum batch size",
         description="",
@@ -4086,8 +4092,7 @@ Auto Scaling Group Roling Update Policy
         title="Minimum instances in service",
         description="Healthy success timeout",
         required=False,
-        default='PT0S'
-        #constraint=IsValidUpdatePolicyPauseTime
+        default='',
     )
     wait_on_resource_signals = schema.Bool(
         title="Wait for resource signals",
@@ -4097,7 +4102,7 @@ Auto Scaling Group Roling Update Policy
 
 class IASG(IResource, IMonitorable):
     """
-An Auto Scaling Group (ASG) contains a collection of Amazon EC2 instances that are treated as a
+An AutoScalingGroup (ASG) contains a collection of Amazon EC2 instances that are treated as a
 logical grouping for the purposes of automatic scaling and management.
 
 The Paco ASG resource provisions an AutoScalingGroup as well as LaunchConfiguration and TargetGroups
@@ -4135,7 +4140,6 @@ for that ASG.
     that will install a CloudWatch Agent and configure it to collect all specified metrics and log sources.
 
     ``secrets``: Adds a policy to the Instance Role which allows instances to access the specified secrets.
-
 
 .. code-block:: yaml
     :caption: example ASG configuration
@@ -4184,8 +4188,6 @@ for that ASG.
     segment: private
     termination_policies:
       - Default
-    update_policy_max_batch_size: 1
-    update_policy_min_instances_in_service: 0
     scaling_policy_cpu_average: 60
     launch_options:
         cfn_init_config_sets:
@@ -4238,14 +4240,93 @@ for that ASG.
     user_data_script: |
       echo "Hello World!"
 
+
+AutoScalingGroup Rolling Update Policy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When changes are applied to an AutoScalingGroup that modify the configuration of newly launched instances,
+then AWS can automatically launch instances with the new configuration and terminate old instances with stale configuration.
+Typically this can be configured so that there is no interruprtion to service as the new instances replace old ones.
+This configuration is set with the ASGs ``rolling_update_policy`` field.
+
+The rolling update policy must be able to work within the minimum/maximum number of instances in the ASG.
+Consider the following ASG configuration.
+
+.. code-block:: yaml
+    :caption: example ASG configuration
+
+    type: ASG
+    max_instances: 2
+    min_instances: 1
+    desired_capacity: 1
+    rolling_update_policy:
+      max_batch_size: 1
+      min_instances_in_service: 1
+      pause_time: PT0S # default setting
+      wait_on_resource_signals: false # default setting
+
+This will normally run a single instance in the ASG. The ASG is never allowed to launch more than 2 instances at one time.
+When an update happens, a new batch of instances is launched - in this configuration just one instance. After the instance
+is put into service by the ASG, it will immediately terminate the old instance.
+
+The ``wait_on_resource_signals`` can be set to tell AWS CloudFormation updates to wait until a new instance is finished
+configuring and installing applications and is ready for service. If this field is enabled, then the ``pause_time``
+default is PT05 (5 minutes). If CloudFormation does not get a SUCCESS signal within the ``pause_time`` then it will
+mark the new instance as failed and terminate it.
+
+If you use ``pause_time`` without ``wait_on_resource_signals`` then AWS will simply wait for the full duration of the
+pause time and then consider the instance ready. ``pause_time`` is in format PT#H#M#S, where each # is the number of
+hours, minutes, and seconds, respectively. The maximum ``pause_time`` is one hour. For example:
+
+.. code-block:: yaml
+    pause_time: PT0S # 0 seconds
+    pause_time: PT5M # 5 minutes
+    pause_time: PT2M30S # 2 minutes and 30 seconds
+
+If you do not want to use an update policies, then you must disable the ``rolling_update_policy`` explicitly:
+
+.. code-block:: yaml
+
+    type: ASG
+    rolling_update_policy:
+      enabled: false
+
+With no rolling update policy, when you make configuration changes, then existing instances with old configuration will
+continue to run and instances with the new configuration will not happen until the AutoScalingGroup needs to launch new
+instances. You must be careful with this approach as you can not know 100% that your new configuration launches instances
+proprely until some point in the future when new instances are requested by the ASG.
+
+.. sidebar:: Prescribed Automation
+
+    Paco can help you send signals to CloudFormation when using ``pause_time`` and ``wait_on_resource_signals``.
+    If you set ``wait_on_resource_signals: true``or use a ``pause_time`` value greater than 0 seconds, then Paco will
+    automatically grant the needed ``cloudformation:SignalResource`` and ``cloudformation:DescribeStacks`` to the IAM Role associated
+    with the instance for you. Paco also provides a ``ec2lm_signal_asg_resource`` BASH function available in your ``user_data_script``
+    that you can run to signal the instance is ready: ``ec2lm_signal_asg_resource SUCCESS`` or ``ec2lm_signal_asg_resource SUCCESS``.
+
+    Note that if you are using additional tooling to install applications, such as CodeDeploy, you will need to signal CloudFormation
+    using another method. For example, if you are using ELB health checks, you can wait until those health checks
+    are passing and then signal the CloudFormation.
+
+        .. code-block:: bash
+            :caption: example ASG signal
+
+            'until [ "$state" == "\"InService\"" ]; do state=$(aws --region ${AWS::Region} elb describe-instance-health
+            --load-balancer-name ${ElasticLoadBalancer}
+            --instances $(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+            --query InstanceStates[0].State); sleep 10; done'
+
+
+For more information on how this policy configuration is used by AWS see their `UpdatePolicy`_ documentation.
+
+.. _UpdatePolicy: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-replacingupdate
+
     """
     @invariant
     def min_instances(obj):
         if obj.rolling_update_policy != None:
             if obj.rolling_update_policy != None and obj.rolling_update_policy.min_instances_in_service >= obj.max_instances:
                 raise Invalid("ASG rolling_update_policy.min_instances_in_service must be less than max_instances.")
-        elif obj.update_policy_min_instances_in_service >= obj.max_instances:
-            raise Invalid("ASG update_policy_min_instances_in_service must be less than max_instances.")
         if obj.min_instances > obj.max_instances:
             raise Invalid("ASG min_instances must be less than or equal to max_instances.")
         if obj.desired_capacity > obj.max_instances:
@@ -4400,18 +4481,6 @@ for that ASG.
         default=1,
         required=False,
     )
-    update_policy_max_batch_size = schema.Int(
-        title="Update policy maximum batch size",
-        description="",
-        default=0,
-        required=False,
-    )
-    update_policy_min_instances_in_service = schema.Int(
-        title="Update policy minimum instances in service",
-        description="",
-        default=0,
-        required=False,
-    )
     scaling_policies = schema.Object(
         title='Scaling Policies',
         schema=IASGScalingPolicies,
@@ -4481,8 +4550,7 @@ for that ASG.
         title="Rolling Update Policy",
         description="",
         schema=IASGRollingUpdatePolicy,
-        default=None,
-        required=False
+        required=True
     )
 
 

--- a/src/paco/models/tests/test_loader.py
+++ b/src/paco/models/tests/test_loader.py
@@ -81,6 +81,12 @@ class Testpacodemo(BaseTestModelLoader):
         demo_env = self.project['netenv']['pacodemo']['demo']['us-west-2']
         asg = demo_env.applications['app'].groups['site'].resources['webapp']
 
+        # rolling_udpate_policy
+        assert asg.rolling_update_policy.max_batch_size == 1
+        assert asg.rolling_update_policy.min_instances_in_service == 0
+        assert asg.rolling_update_policy.pause_time == 'PT1M'
+        assert asg.rolling_update_policy.wait_on_resource_signals == False
+
         # CloudFormation Init
         cfn_init = asg.cfn_init
         assert schemas.ICloudFormationInit.providedBy(cfn_init)


### PR DESCRIPTION
This remove the update_policy_max_batch_size and update_policy_min_instances_in_service from the model completely.

It adds documentation which describes the intended behaviour.

See the docs on signalling with ec2lm_signal_asg_resource. I have some cfn-init to signal an ALB health check, but haven't put it in here. Ideally work that into a prescribed automation somehow?

The other question to review is the defaults for max_batch_size and min_instances_in_service? They are 1/1 right now, but have had different defaults. Are those what we want?

Also the pause_time default is now '' and is considered 0 seconds if no wait on resource signals, or 5 minutes if wait on resource signals is true by Paco. This is inline with the AWS CFN defaults.